### PR TITLE
Handle spread operator in attributes

### DIFF
--- a/__tests__/lib/findVariablesInTemplate.js
+++ b/__tests__/lib/findVariablesInTemplate.js
@@ -111,4 +111,15 @@ describe('findVariablesInTemplate', () => {
 
     expect(result).toEqual(expected)
   })
+
+  it('handles object spread operator to support jsx', () => {
+    const result = findVariables(`
+      Component(...field ...props[value])
+    `)
+    const expected = [
+      'Component', 'field', 'props', 'value',
+    ]
+
+    expect(result).toEqual(expected)
+  })
 })

--- a/lib/findVariablesInTemplate.js
+++ b/lib/findVariablesInTemplate.js
@@ -5,25 +5,26 @@ const babylon = require('babylon')
 const codeWalk = require('babel-traverse').default
 
 const isComponent = string => /^[A-Z].*$/.test(string)
+const isSpreadOperator = string => /^\.{3}[A-z]+$/.test(string)
 
 const parseAndFindVarsInProgram = (program) => {
   const out = []
-  const code = babylon.parse(program)
+  const code = babylon.parse(program, {
+    plugins: [
+      'objectRestSpread',
+    ],
+  })
 
   codeWalk(code, {
-    enter(path) {
-      if (path.type === 'ExpressionStatement') {
-        const varsInGlobal = Object.keys(path.scope.globals)
+    Program(path) {
+      const varsInGlobal = Object.keys(path.scope.globals)
 
-        out.push(...varsInGlobal)
-      }
+      out.push(...varsInGlobal)
     },
   })
 
   return out
 }
-
-const prepareValueToBeParsed = value => String(value)
 
 const findVariablesInTemplate = (template) => {
   if (template) {
@@ -39,7 +40,10 @@ const findVariablesInTemplate = (template) => {
         }
 
         node.attrs.forEach((attribute) => {
-          const value = prepareValueToBeParsed(attribute.val)
+          const value = isSpreadOperator(attribute.name)
+            ? `({${attribute.name}})`
+            : String(attribute.val)
+
           const vars = parseAndFindVarsInProgram(value)
 
           variables.push(...vars)


### PR DESCRIPTION
Make pug more compatible with jsx syntax by supporting of object spread operator in attributes.

```jsx
pug`
  Component(...props text="String")
`
```