### PR TITLE
Add test case for templates with more than one root

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,13 @@ const pugTemplate = `
     if condition === matcher
       p Truthy
     
-`.trim()
+`.trimRight()
 
 const variables = findVariablesInTemplate(pugTemplate)
 // is equal ['ReactComponent', 'object', 'item', 'content', 'condition', 'matcher']
 ```
+
+**Important**: templates should be right-trimmed. Usually it means that you have to execute `.trimRight` on your template-string as in the example above.
 
 ## Value
 

--- a/__tests__/lib/findVariablesInTemplate.js
+++ b/__tests__/lib/findVariablesInTemplate.js
@@ -1,6 +1,6 @@
 const findVariablesInTemplate = require('../../lib/findVariablesInTemplate')
 
-const findVariables = template => findVariablesInTemplate(template.trim())
+const findVariables = template => findVariablesInTemplate(template.trimRight())
 
 describe('findVariablesInTemplate', () => {
   it('returns empty array by default', () => {
@@ -181,6 +181,23 @@ describe('findVariablesInTemplate', () => {
     const expected = [
       'nestedVariable', 'doubleNestedVariable', 'collection', 'outsideVariable', 'item',
     ]
+
+    expect(result).toEqual(expected)
+  })
+
+  it('handles more than one root', () => {
+    const result = findVariables(`
+      if true
+        = first
+
+      else if false
+        = second
+
+      else
+        = third
+    `)
+
+    const expected = ['first', 'second', 'third']
 
     expect(result).toEqual(expected)
   })


### PR DESCRIPTION
We have to use `.trimRight()` for templates before passing them to `findVariablesInTemplate`