### PR TITLE
Find variables correctly in LOC

### DIFF
--- a/__tests__/lib/findVariablesInTemplate.js
+++ b/__tests__/lib/findVariablesInTemplate.js
@@ -131,6 +131,7 @@ describe('findVariablesInTemplate', () => {
     const result = findVariables(`
       Header(key=item.id)
         Nested(attr=text)= value
+      Box Hello from Box's child
     `)
     const expected = [
       buildVariable('Header', [2, 6], [2, 12]),
@@ -138,6 +139,7 @@ describe('findVariablesInTemplate', () => {
       buildVariable('Nested', [3, 8], [3, 14]),
       buildVariable('text', [3, 20], [3, 24]),
       buildVariable('value', [3, 27], [3, 32]),
+      buildVariable('Box', [4, 6], [4, 9]),
     ]
 
     expect(result).toEqual(expected)

--- a/src/helpers/variables.js
+++ b/src/helpers/variables.js
@@ -20,7 +20,7 @@ export function buildVariable(name: string, startCoord: Coord, endCoord: Coord):
 
 export function findVariable(name: string, location: SourceLocation, source: Array<string>): Variable {
   const line = location.start.line
-  const valueStartsAt = location.start.column
+  const valueStartsAt = location.start.column - 1
   const columnStart = valueStartsAt + source[0].substring(valueStartsAt).indexOf(name)
   const columnEnd = columnStart + name.length
 


### PR DESCRIPTION
When we find location of variable in the line of code it has a mistake that it started from 1 instead of 0.

Example of what location it took previously and what it takes now:

```
        Box Hello from Box's child
before: ---------------^^^--------
now:    ^^^-----------------------
```